### PR TITLE
fix sample-android project, NullPointerException

### DIFF
--- a/sample-android/src/main/java/com/ekchang/jsouper/sample/api/PlayStoreApi.java
+++ b/sample-android/src/main/java/com/ekchang/jsouper/sample/api/PlayStoreApi.java
@@ -8,6 +8,6 @@ import retrofit2.http.GET;
 public interface PlayStoreApi {
   String BASE_URL = "https://play.google.com/store/";
 
-  @GET("movies/collection/promotion_400079b_most_popular_movies")
+  @GET("movies/collection/promotion_4000a71_newrelease_mo_eg_ac")
   Call<List<Movie>> getMovies();
 }


### PR DESCRIPTION
existing promotion was over.

```
02-05 21:10:48.006 17020-17020/? E/AndroidRuntime: FATAL EXCEPTION: main
Process: com.ekchang.jsouper.sample, PID: 17020
java.lang.NullPointerException: Attempt to invoke interface method 'java.lang.Object[] java.util.Collection.toArray()' on a null object reference
  at java.util.ArrayList.addAll(ArrayList.java:188)
  at com.ekchang.jsouper.sample.MoviesAdapter.loadData(MoviesAdapter.java:47)
  at com.ekchang.jsouper.sample.PlayStoreActivity$1.onResponse(PlayStoreActivity.java:53)
  at retrofit2.ExecutorCallAdapterFactory$ExecutorCallbackCall$1$1.run(ExecutorCallAdapterFactory.java:68)
  at android.os.Handler.handleCallback(Handler.java:739)
  at android.os.Handler.dispatchMessage(Handler.java:95)
  at android.os.Looper.loop(Looper.java:135)
  at android.app.ActivityThread.main(ActivityThread.java:5254)
  at java.lang.reflect.Method.invoke(Native Method)
  at java.lang.reflect.Method.invoke(Method.java:372)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
```